### PR TITLE
Fix error message for upper bound type check

### DIFF
--- a/spans/types.py
+++ b/spans/types.py
@@ -124,7 +124,7 @@ class Range(PartialOrderingMixin, PicklableSlotMixin):
 
         if upper is not None and not isinstance(upper, self.type):
             raise TypeError(
-                f"Invalid type for lower bound '{upper.__class__.__name__}'"
+                f"Invalid type for upper bound '{upper.__class__.__name__}'"
                 f" expected '{self.type.__name__}'"
             )
 

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -66,6 +66,11 @@ def test_invalid_construction(range_type, lower, upper, lower_inc, upper_inc, ex
         range_type(lower, upper, lower_inc, upper_inc)
 
 
+def test_invalid_upper_bound_message():
+    with pytest.raises(TypeError, match="upper bound"):
+        intrange(1, 1.5)
+
+
 @pytest.mark.parametrize(
     "range_type, lower, upper",
     [


### PR DESCRIPTION
## Summary
- correct wording when validating `upper`
- test that an incorrect upper bound type mentions `upper bound`

## Testing
- `pytest -q`