### PR TITLE
Fix typos in module docstring

### DIFF
--- a/spans/__init__.py
+++ b/spans/__init__.py
@@ -2,12 +2,12 @@
 This module provides one dimensional continuous set support for python.
 
 Python has a wonderful set class, it does however not handle continuous sets
-between two endpoints. This module tries to mitigate that. The ranges' behavoir
+between two endpoints. This module tries to mitigate that. The ranges' behavior
 are modeled after PostgresSQL 9.2's range types. Deviating from PostgresSQL's
-behavoir is considered a bug.
+behavior is considered a bug.
 
 In addition to the range types there are range sets. A range set is can be viewed
-as a mutable list of ranges. A set enables discontinious chunks to be grouped
+as a mutable list of ranges. A set enables discontinuous chunks to be grouped
 together.
 """
 


### PR DESCRIPTION
## Summary
- fix typos in `spans/__init__.py`

## Testing
- `pytest -q`